### PR TITLE
[DUPLICATE] Issue #10 already fixed in #8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: undefined
+Your prepared branch: issue-10-7c5b1aa6
+Your prepared working directory: /tmp/gh-issue-solver-1764166151827
+Your forked repository: unidel2035/hives
+Original repository (upstream): judas-priest/hives
+
+Proceed.


### PR DESCRIPTION
## Summary

This PR was created to address issue #10, but upon investigation, I found that **the issue has already been fixed** in commit `cbafb9b` which was created for issue #8.

### Root Cause Analysis

The error `getenv is not a function` occurred because:
1. `config.lib.mjs` was using `await use('getenv')` instead of `await globalThis.use('getenv')`
2. When modules were imported via static imports before `globalThis.use` was set up in the main entry point, the `use` variable was undefined in the module scope

### The Fix (Already Applied)

**Commit**: cbafb9bcd36543413872033b4106207056bcfa53
**Changes**: 
- Changed `await use('getenv')` to `await globalThis.use('getenv')` in `config.lib.mjs`
- Same fix applied to `telegram-bot.mjs`

This ensures the use function is correctly resolved when these modules are imported early in the initialization chain.

### Verification

I have verified the fix is working by:
1. Running the exact command from the issue report: `./src/solve.mjs https://github.com/judas-priest/test/issues/126 --tool polza --model anthropic/claude-sonnet-4.5`
2. Testing various edge cases of module import order
3. Confirming `globalThis.use('getenv')` returns a function and works correctly

**Result**: The command runs successfully without any 'getenv is not a function' error.

### Conclusion

- Issue #10 is a **duplicate of issue #8**
- The fix is **already merged** to the main branch
- **No code changes are needed** in this PR
- The issue reporter likely reported this before pulling the latest changes

### Recommendation

Close this PR and issue #10 as duplicate/already fixed.

---
*Investigation completed by Claude Code*