### PR TITLE
Fix build.js to read shebang from original.js (Issue #40)

### DIFF
--- a/k_da/build.js
+++ b/k_da/build.js
@@ -23,18 +23,13 @@ console.log('Building k_da.js from split sources...\n');
 
 // Files to concatenate in order
 const sourceFiles = [
+  'src/00-shebang.js',
   'src/01-webpack-runtime.js',
   'src/02-react-bundle.js',
   'src/03-npm-modules.js',
   'src/04-app-code.js',
   'src/05-main.js',
 ];
-
-// Read the shebang and imports from original.js (lines 1-2)
-// We use original.js instead of k_da_deobfuscated.js since it's the source file
-const originalFile = path.join(__dirname, 'original.js');
-const originalLines = fs.readFileSync(originalFile, 'utf8').split('\n');
-const shebang = originalLines.slice(0, 2).join('\n');
 
 // Load .env file if it exists
 let envVars = {};
@@ -124,8 +119,8 @@ function inlineEnvironmentVariables(content) {
   return content;
 }
 
-// Start with shebang
-let output = shebang + '\n\n';
+// Start with empty output (shebang will come from 00-shebang.js)
+let output = '';
 
 // Concatenate all source files
 sourceFiles.forEach((file, index) => {
@@ -135,6 +130,12 @@ sourceFiles.forEach((file, index) => {
 
   // Remove the header comment (everything before the first non-comment line)
   content = content.replace(/^\/\*[\s\S]*?\*\/\s*/, '');
+
+  // Special handling for 00-shebang.js - add proper spacing after it
+  if (file === 'src/00-shebang.js') {
+    output += content + '\n\n';
+    return;
+  }
 
   // Special handling for 04-app-code.js - replace i18n import with inline data
   if (file === 'src/04-app-code.js') {

--- a/k_da/k_da-tools.js
+++ b/k_da/k_da-tools.js
@@ -195,9 +195,24 @@ function splitFile() {
     ];
   }
 
+  // First, create the shebang file (lines 1-2 from k_da_deobfuscated.js)
+  log(`[0/${splits.length + 1}] Creating src/00-shebang.js...`);
+  const shebangLines = lines.slice(0, 2);
+  const shebangContent = shebangLines.join("\n");
+  const shebangPath = path.join(__dirname, "src/00-shebang.js");
+
+  let shebangFileContent = `/**\n * Shebang and module setup\n`;
+  shebangFileContent += ` * Lines 1-2 from original k_da_deobfuscated.js\n`;
+  shebangFileContent += ` * This file contains the Node.js shebang and ES module compatibility setup\n */\n\n`;
+  shebangFileContent += shebangContent;
+
+  fs.writeFileSync(shebangPath, shebangFileContent);
+  const shebangSizeMB = (shebangFileContent.length / 1024 / 1024).toFixed(2);
+  success(`00-shebang.js - ${shebangLines.length.toLocaleString()} lines, ${shebangSizeMB} MB`);
+
   // Extract each section
   splits.forEach((split, index) => {
-    log(`[${index + 1}/${splits.length}] Creating ${split.filename}...`);
+    log(`[${index + 1}/${splits.length + 1}] Creating ${split.filename}...`);
 
     const sectionLines = lines.slice(split.start, split.end);
     const sectionContent = sectionLines.join("\n");


### PR DESCRIPTION
## Summary

This PR fixes issue #40 by making `build.js` completely independent of `original.js`. Now the build process works purely from the `src/` directory, which is the correct approach for a modular build system.

## Problem Analysis

The original issue reported:
```
ENOENT: no such file or directory, open '.../k_da/k_da_deobfuscated.js'
```

Additionally, the user correctly pointed out: **"Why do I even need the original file for building if the code is deobfuscated and broken? I NEED TO BUILD FROM /src"**

The previous implementation had `build.js` reading the shebang from `original.js`, creating an unnecessary dependency. If the build is meant to work from split source files, it should only depend on those source files.

## Solution

### Changes Made

**1. Modified `k_da-tools.js` (split function)**
- Added creation of `src/00-shebang.js` containing lines 1-2 from `k_da_deobfuscated.js`
- This file stores:
  - Line 1: `#!/usr/bin/env node` (shebang)
  - Line 2: ESM compatibility setup (`import { createRequire }...`)

**2. Modified `build.js`**
- Added `src/00-shebang.js` as the first source file in the build array
- Removed dependency on `original.js` entirely
- Added special handling for the shebang file to preserve correct formatting
- Build now works purely from `src/` directory

## Workflow

### Before (broken):
```bash
$ cd k_da
$ node build.js
ENOENT: no such file or directory, open '.../k_da_deobfuscated.js'
```

### After (works correctly):
```bash
$ cd k_da
$ node k_da-tools.js deobfuscate  # Creates k_da_deobfuscated.js from original.js
$ node k_da-tools.js split        # Creates src/ with 00-shebang.js + other files
$ node k_da-tools.js extract-i18n # Creates src/i18n/ locale files
$ node build.js                   # ✅ Works! No dependency on original.js
```

Or use the all-in-one command:
```bash
$ node k_da-tools.js all
```

## Testing

### Build Output:
```
Building k_da.js from split sources...

Loading .env file...
   → Loaded 6 environment variables from .env
Loading i18n locale data...
[1/6] Adding src/00-shebang.js...
[2/6] Adding src/01-webpack-runtime.js...
[3/6] Adding src/02-react-bundle.js...
[4/6] Adding src/03-npm-modules.js...
[5/6] Adding src/04-app-code.js...
   → Inlining i18n locale data...
   → Removing old hard-coded i18n objects from app code...
   → Removed old English locale object
   → Removed old Russian locale object
[6/6] Adding src/05-main.js...

✓ Built /tmp/.../k_da/k_da.js (6.12 MB)
✓ i18n locale data inlined successfully
✓ Environment variables from .env set as defaults
```

### File Structure After Split:
```
k_da/
├── src/
│   ├── 00-shebang.js          # NEW: Contains shebang + ESM setup
│   ├── 01-webpack-runtime.js
│   ├── 02-react-bundle.js
│   ├── 03-npm-modules.js
│   ├── 04-app-code.js
│   ├── 05-main.js
│   └── i18n/
│       └── locales/
│           ├── en-US.js
│           └── ru-RU.js
```

## Benefits

1. ✅ **Cleaner separation**: `original.js` is only needed for deobfuscation
2. ✅ **Modular workflow**: Each step depends only on the previous step's output
3. ✅ **Easier development**: Can modify `src/` files and rebuild without touching `original.js`
4. ✅ **Better organization**: Shebang is now part of the source structure

## Known Issue: Minified File Support

⚠️ **Important**: The current codebase has a pre-existing issue with minified files. When `original.js` is minified (all code on a few lines), the split boundaries don't work correctly, resulting in broken syntax in the split files. This causes runtime errors:

```
SyntaxError: Unexpected identifier 'you'
    at compileSourceTextModule (node:internal/modules/esm/utils:346:16)
```

This issue exists because:
- The split is based on line numbers (lines 5, 6, 7, 8, etc.)
- In a minified file, all the code is on lines 3-4
- This results in mostly empty files (01, 02, 03) and fragmented code

### Workaround:
The workflow expects `prettier` to format the code first during deobfuscation:
```bash
npm install prettier  # Install prettier
node k_da-tools.js all  # Will format before splitting
```

This is a separate issue from #40 and should be addressed in a future PR.

## Fixes

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)